### PR TITLE
Add workflow to

### DIFF
--- a/.github/workflows/manualRelease.yaml
+++ b/.github/workflows/manualRelease.yaml
@@ -1,0 +1,62 @@
+name: Manual release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:  
+        description: 'Add-on version'
+        required: true
+        default: '0.0.0'
+      prerelease:
+        description: 'Mark as prerelease on GitHub'
+        default: false
+        type: boolean
+
+jobs:
+  buildAndUpload:
+    runs-on: ubuntu-latest
+
+    steps:
+    - id: checkoutCode
+      name: Checkout code
+      uses: actions/checkout@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+    - name: Install dependencies
+      run: |
+        pip install scons markdown
+        sudo apt update
+        sudo apt install gettext
+    - name: Add add-on version
+      run: |
+        import re
+        with open("buildVars.py", 'r+', encoding='utf-8') as f:
+          text = f.read()
+          version = "${{ github.event.inputs.version }}"
+          text = re.sub(r"\"addon_version\": .*?,", f"\"addon_version\": \"{version}\",", text)
+          f.seek(0)
+          f.write(text)
+          f.truncate()
+      shell: python 
+    - name: Build add-on
+      run: scons
+    - name: Push changes
+      run: |
+        git config --global user.name github-actions
+        git config --global user.email github-actions@github.com
+        git commit -a -m "Update buildVars"
+        git push
+    - name: Create tag
+      run: |
+        git tag ${{ inputs.version }}
+        git push origin ${{ inputs.version }}
+    - name: Release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ inputs.version }}
+        artifacts: "*.nvda-addon"
+        generateReleaseNotes: true
+        prerelease: ${{ inputs.prerelease }}
+        


### PR DESCRIPTION
### Summary of the issue

The workflow availableon this repo fails to publish releases.

### Development strategy

I've modified the workflow used by me removing features which seem not to be used in this add-on, like publishing sha256 and GPG signature assets.
Note that, with this workflow, you don't need to open the buildVars.py file to indicate the version to be published,since it will be writen by GitHub Actions. buildVars.py may need to be modified if, by mistake, you want to release the same version indicated in buildVars, but not generally.
The workflow can be run manually from the actions link of this repo, or using GH CLI from your computer. You need to specify the desired version and marking the checkbox to reflect if this would be a prerelease, if you run it from GitHub. If you run it from your computer, you will need to type the version and true of false to indicate if this is a prerelease.

### Testing performed


https://github.com/nvdaes/BMI/actions/runs/8857018524

https://github.com/nvdaes/BMI/releases/tag/0.0.0

@edilbertofonseca, if this doesn't work for you, we can try to set write permissions for contents in the job. Please feel free to review this.
